### PR TITLE
"Invalid ISBN" might not be correct

### DIFF
--- a/browser/src/store/index.ts
+++ b/browser/src/store/index.ts
@@ -53,7 +53,7 @@ function buildBookParams(book: Model.Book): URLSearchParams {
 function extractBookFromOpenBDResponse(response: AxiosResponse): Model.Book {
   const data = response.data[0];
   if (!data) {
-    throw new Error('invalid ISBN');
+    throw new Error('ISBN not found');
   }
   const convertPubdate = (pubdate: string): string => {
     const year = pubdate.slice(0, 4);


### PR DESCRIPTION
openbd doesn't have a lot of books in the database. Out of ~1600 books in my library, less than 30 were found. The ISBNs validated correctly with isbnlib, and have metadata in other sources.

This diff updates the message to just say "not found" since opendb returns `[null]` for both "thisisnotanisbn" and for a valid isbn that is not found.